### PR TITLE
improve specta/rspc integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ serde_json = "1.0.108"
 strum = "0.25"
 strum_macros = "0.25.3"
 async-recursion = "1.0.5"
-rspc = { version = "0.1.3" }
+specta = { version = "1.0.5" }

--- a/src/groups/groups.rs
+++ b/src/groups/groups.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 

--- a/src/groups/join_requests.rs
+++ b/src/groups/join_requests.rs
@@ -1,5 +1,5 @@
 pub mod join_requests {
-    use rspc::Type;
+    use specta::Type;
     use serde::{Deserialize, Serialize};
 
     use crate::{
@@ -89,7 +89,7 @@ pub mod join_requests {
 }
 
 pub mod join_request {
-    use rspc::Type;
+    use specta::Type;
     use serde::{Deserialize, Serialize};
 
     use crate::{

--- a/src/groups/membership.rs
+++ b/src/groups/membership.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::util::{jar::RequestJar, responses::RobloxError, Error};

--- a/src/groups/metadata.rs
+++ b/src/groups/metadata.rs
@@ -1,5 +1,5 @@
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 
 use crate::util::{jar::RequestJar, Error};
 

--- a/src/groups/permissions.rs
+++ b/src/groups/permissions.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::util::{jar::RequestJar, responses::DataWrapper, Error};

--- a/src/groups/primary.rs
+++ b/src/groups/primary.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::util::{jar::RequestJar, Error};

--- a/src/groups/relationships.rs
+++ b/src/groups/relationships.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 

--- a/src/groups/revenue.rs
+++ b/src/groups/revenue.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/groups/roles.rs
+++ b/src/groups/roles.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/groups/search.rs
+++ b/src/groups/search.rs
@@ -1,5 +1,5 @@
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 
 use crate::util::{jar::RequestJar, paging::PageLimit, responses::DataWrapper, Error};
 

--- a/src/groups/social_links.rs
+++ b/src/groups/social_links.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 

--- a/src/groups/wall.rs
+++ b/src/groups/wall.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/thumbnails/types.rs
+++ b/src/thumbnails/types.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 // TODO: Document this

--- a/src/users/display_names.rs
+++ b/src/users/display_names.rs
@@ -1,5 +1,5 @@
 use reqwest::StatusCode;
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/users/username_search.rs
+++ b/src/users/username_search.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/users/usernames.rs
+++ b/src/users/usernames.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/users/users.rs
+++ b/src/users/users.rs
@@ -4,7 +4,7 @@ use crate::{
     util::Error,
     util::{jar::RequestJar, responses::DataWrapper},
 };
-use rspc::Type;
+use specta::Type;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 #[serde(rename_all = "camelCase")]

--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 

--- a/src/util/responses.rs
+++ b/src/util/responses.rs
@@ -1,4 +1,4 @@
-use rspc::Type;
+use specta::Type;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]


### PR DESCRIPTION
Changes:
 - Depend on `specta::Type` instead of `rspc::Type` as it will work with rspc along with other Specta crates such as [Tauri Specta](https://github.com/oscartbeaumont/tauri-specta)